### PR TITLE
fix(ci): correct keystore path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,37 @@ jobs:
       - name: Generate app icons
         run: dart run flutter_launcher_icons
 
+      # Configure Android signing
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > android/app/upload-keystore.jks
+        shell: bash
+
+      - name: Create key.properties
+        run: |
+          cat > android/key.properties << EOF
+          storePassword=${{ secrets.KEYSTORE_PASSWORD }}
+          keyPassword=${{ secrets.KEY_PASSWORD }}
+          keyAlias=${{ secrets.KEY_ALIAS }}
+          storeFile=upload-keystore.jks
+          EOF
+        shell: bash
+
       # Semantic Release (analyzes commits, builds artifacts, creates release with assets)
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
         run: npx semantic-release
+
+      # Upload to Google Play Store
+      - name: Upload to Google Play Store
+        if: success()
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          packageName: com.michieldean.foster_squirrel
+          releaseFiles: build/app/outputs/bundle/release/*.aab
+          track: production
+          status: completed
+          whatsNewDirectory: distribution/whatsnew
+          mappingFile: android/build/app/outputs/mapping/release/mapping.txt


### PR DESCRIPTION
Fixes Android release signing issue where releases were signed in debug mode. Updated storeFile path from upload-keystore.jks to app/upload-keystore.jks in the GitHub Actions workflow.